### PR TITLE
feat: Docs 페이지 ui 구현 (#7)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-echo "npx lint-staged" > .husky/pre-commit
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-config-next": "15.4.6",
         "husky": "^9.1.7",
         "lint-staged": "^16.1.5",
+        "prettier": "^3.6.2",
         "tailwindcss": "^4",
         "typescript": "^5"
       }
@@ -5356,6 +5357,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-next": "15.4.6",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "prettier": "^3.6.2",
     "tailwindcss": "^4",
     "typescript": "^5"
   },

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,0 +1,40 @@
+import Sidebar from '@/components/docs/Sidebar';
+
+export default function DocsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className='grid grid-cols-1 lg:grid-cols-[280px_1fr] min-h-screen'>
+      {/* 사이드바 - 모바일에서는 숨김, 데스크탑에서는 고정 */}
+      <div className='hidden lg:block'>
+        <Sidebar />
+      </div>
+
+      {/* 메인 콘텐츠 */}
+      <main className='overflow-auto'>
+        {/* 모바일 햄버거 버튼 */}
+        <div className='lg:hidden p-4 border-b border-gray-200 bg-white sticky top-0 z-10'>
+          <button className='text-gray-600 hover:text-gray-900'>
+            <svg
+              className='w-6 h-6'
+              fill='none'
+              stroke='currentColor'
+              viewBox='0 0 24 24'
+            >
+              <path
+                strokeLinecap='round'
+                strokeLinejoin='round'
+                strokeWidth={2}
+                d='M4 6h16M4 12h16M4 18h16'
+              />
+            </svg>
+          </button>
+        </div>
+
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,0 +1,82 @@
+import SearchBar from '@/components/docs/SearchBar';
+
+export default function DocsPage() {
+  return (
+    <div className='bg-white min-h-screen'>
+      <div className='max-w-4xl mx-auto px-4 py-16'>
+        {/* 헤더 섹션 */}
+        <div className='text-center mb-12'>
+          <h1 className='text-5xl font-bold text-gray-900 mb-6'>
+            개발 공부...
+          </h1>
+          <p className='text-xl text-gray-600 mb-4'>
+            봐야할 건 너무 많은데, 그조차도 설명 자체가 어렵다니...
+          </p>
+          <p className='text-lg text-gray-500 mb-12'>
+            조금 더 쉽게 쉽게 이해해봅시다.
+          </p>
+
+          <SearchBar />
+        </div>
+
+        {/* 기여 가이드 섹션 */}
+        <div className='mt-16 bg-gray-50 rounded-xl p-8'>
+          <div className='space-y-6'>
+            <p className='text-gray-700 text-center'>
+              이 사이트의 모든 문서는 GitHub에서 관리됩니다. <br />
+              새로운 글을 작성하거나 기존 글을 수정하고 싶다면 GitHub 저장소에서
+              기여해주세요.
+            </p>
+
+            <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+              <div className='bg-white rounded-lg p-6 border border-gray-200'>
+                <h3 className='text-lg font-medium text-gray-900 mb-3'>
+                  새 문서 작성
+                </h3>
+                <p className='text-gray-600 mb-4 text-sm'>
+                  어려운 공식문서나 개념을 쉽게 설명한 글을 마크다운으로
+                  작성해주세요.
+                </p>
+                <a
+                  href='https://github.com/DevsPlatform/devsplatform-docs'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-blue-600 hover:text-blue-700'
+                >
+                  docs 저장소 →
+                </a>
+              </div>
+
+              <div className='bg-white rounded-lg p-6 border border-gray-200'>
+                <h3 className='text-lg font-medium text-gray-900 mb-3'>
+                  기존 문서 수정
+                </h3>
+                <p className='text-gray-600 mb-4 text-sm'>
+                  오타나 잘못된 내용을 발견했다면 언제든 수정 제안을 해주세요.
+                </p>
+                <a
+                  href='https://github.com/DevsPlatform/devsplatform-docs/pulls'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='text-green-600 hover:text-green-700'
+                >
+                  Pull Request 보기 →
+                </a>
+              </div>
+            </div>
+
+            <div className='text-center pt-4'>
+              <p className='text-sm text-gray-500'>
+                GitHub 사용이 처음이라면{' '}
+                <a href='#' className='text-blue-600 hover:text-blue-700'>
+                  가이드
+                </a>
+                를 참고하세요.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/docs/SearchBar.tsx
+++ b/src/components/docs/SearchBar.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+// SearchResult 타입 정의
+interface SearchResult {
+  title: string;
+  description: string;
+  icon: string;
+  category: string;
+}
+
+export default function SearchBar() {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [filteredResults, setFilteredResults] = useState<SearchResult[]>([]);
+
+  useEffect(() => {
+    if (searchQuery.length > 0) {
+      const results = mockSearchResults.filter(
+        (item: SearchResult) =>
+          item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          item.description.toLowerCase().includes(searchQuery.toLowerCase())
+      );
+      setFilteredResults(results);
+      setIsOpen(true);
+    } else {
+      setFilteredResults([]);
+      setIsOpen(false);
+    }
+  }, [searchQuery]);
+
+  return (
+    <div className='w-full max-w-2xl mx-auto relative'>
+      {/* 검색 입력창 */}
+      <div className='relative'>
+        {/* 회전하는 그라데이션 테두리 */}
+        <div className='rotating-border'>
+          <div className='relative flex items-center bg-white rounded-full h-full'>
+            <div className='absolute left-4 z-10'>
+              <svg
+                className='w-5 h-5 text-gray-400'
+                fill='none'
+                stroke='currentColor'
+                viewBox='0 0 24 24'
+              >
+                <path
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  strokeWidth={2}
+                  d='M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z'
+                />
+              </svg>
+            </div>
+
+            <input
+              type='text'
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              onFocus={() => searchQuery && setIsOpen(true)}
+              className='w-full pl-12 pr-6 py-4 text-lg bg-transparent focus:outline-none rounded-full text-black'
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* CSS 스타일 */}
+      <style jsx>{`
+        .rotating-border {
+          position: relative;
+          padding: 2px;
+          border-radius: 50px;
+          background: linear-gradient(
+            45deg,
+            #000,
+            #333,
+            #666,
+            #999,
+            #ccc,
+            #999,
+            #666,
+            #333,
+            #000
+          );
+          background-size: 200% 200%;
+          animation: gradientRotate 3s ease-in-out infinite;
+        }
+
+        @keyframes gradientRotate {
+          0% {
+            background-position: 0% 50%;
+          }
+          50% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
+          }
+        }
+      `}</style>
+
+      {/* 검색 결과 오버레이 */}
+      {isOpen && filteredResults.length > 0 && (
+        <>
+          {/* 배경 클릭으로 닫기 */}
+          <div
+            className='fixed inset-0 z-10'
+            onClick={() => setIsOpen(false)}
+          />
+
+          {/* 검색 결과 */}
+          <div className='absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-20 max-h-96 overflow-y-auto'>
+            {filteredResults.map((result, index) => (
+              <div
+                key={index}
+                className='px-4 py-3 hover:bg-gray-50 cursor-pointer border-b border-gray-100 last:border-b-0'
+                onClick={() => {
+                  console.log('선택:', result.title);
+                  setIsOpen(false);
+                }}
+              >
+                <div className='flex items-start'>
+                  <span className='text-lg mr-3 mt-1'>{result.icon}</span>
+                  <div className='flex-1'>
+                    <h4 className='font-medium text-gray-900 mb-1'>
+                      {result.title}
+                    </h4>
+                    <p className='text-sm text-gray-600 mb-1'>
+                      {result.description}
+                    </p>
+                    <span className='text-xs text-blue-600 bg-blue-50 px-2 py-1 rounded'>
+                      {result.category}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* 검색어가 있지만 결과가 없을 때 */}
+      {isOpen && searchQuery && filteredResults.length === 0 && (
+        <>
+          <div
+            className='fixed inset-0 z-10'
+            onClick={() => setIsOpen(false)}
+          />
+          <div className='absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-20 p-4 text-center text-gray-500'>
+            &ldquo;{searchQuery}&rdquo;에 대한 검색 결과가 없습니다.
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+const mockSearchResults = [
+  {
+    title: 'React Hooks 완벽 가이드',
+    description: 'useState, useEffect부터 커스텀 훅까지',
+    icon: '⚛️',
+    category: 'React',
+  },
+  {
+    title: 'Next.js App Router',
+    description: '새로운 라우팅 시스템 완전 정복',
+    icon: '🔷',
+    category: 'Next.js',
+  },
+  {
+    title: 'JavaScript 비동기 처리',
+    description: 'Promise, async/await 쉽게 이해하기',
+    icon: '📜',
+    category: 'JavaScript',
+  },
+  {
+    title: 'TypeScript 기초',
+    description: '타입으로 안전한 코드 작성하기',
+    icon: '🔷',
+    category: 'TypeScript',
+  },
+  {
+    title: 'CSS Flexbox',
+    description: '레이아웃의 혁신, Flexbox 마스터하기',
+    icon: '🎨',
+    category: 'CSS',
+  },
+  {
+    title: 'React useState Hook',
+    description: 'React의 가장 기본적인 상태 관리 훅',
+    icon: '⚛️',
+    category: 'React',
+  },
+  {
+    title: 'JavaScript async/await',
+    description: '비동기 처리를 동기처럼 쉽게',
+    icon: '📜',
+    category: 'JavaScript',
+  },
+];

--- a/src/components/docs/Sidebar.tsx
+++ b/src/components/docs/Sidebar.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+const categories = [
+  {
+    name: '시작하기',
+    icon: '🚀',
+    items: [
+      { name: '소개', href: '/docs/intro' },
+      { name: '설치 가이드', href: '/docs/installation' },
+    ],
+  },
+  {
+    name: 'React',
+    icon: '⚛️',
+    items: [
+      { name: 'React 기초', href: '/docs/react/basics' },
+      { name: 'State & Props', href: '/docs/react/state-props' },
+      { name: 'Hooks', href: '/docs/react/hooks' },
+      { name: 'Context API', href: '/docs/react/context' },
+    ],
+  },
+  {
+    name: 'Next.js',
+    icon: '🔷',
+    items: [
+      { name: 'Next.js 소개', href: '/docs/nextjs/intro' },
+      { name: 'App Router', href: '/docs/nextjs/app-router' },
+      { name: '라우팅', href: '/docs/nextjs/routing' },
+      { name: '서버 컴포넌트', href: '/docs/nextjs/server-components' },
+    ],
+  },
+  {
+    name: 'JavaScript',
+    icon: '📜',
+    items: [
+      { name: 'JS 기초', href: '/docs/javascript/basics' },
+      { name: '비동기 프로그래밍', href: '/docs/javascript/async' },
+      { name: 'ES6+ 문법', href: '/docs/javascript/es6' },
+    ],
+  },
+];
+
+export default function Sidebar() {
+  const [openCategories, setOpenCategories] = useState<string[]>(['React']);
+
+  const toggleCategory = (categoryName: string) => {
+    setOpenCategories(prev =>
+      prev.includes(categoryName)
+        ? prev.filter(name => name !== categoryName)
+        : [...prev, categoryName]
+    );
+  };
+
+  return (
+    <aside className='bg-white border-r border-gray-200 h-screen overflow-y-auto sticky top-0'>
+      <div className='p-6'>
+        <h2 className='text-xl font-bold text-gray-900 mb-6'>Docs</h2>
+
+        <nav className='space-y-2'>
+          {categories.map(category => (
+            <div key={category.name}>
+              <button
+                onClick={() => toggleCategory(category.name)}
+                className='flex items-center justify-between w-full px-3 py-2 text-left text-gray-700 hover:bg-gray-100 rounded-lg transition-colors'
+              >
+                <div className='flex items-center'>
+                  <span className='mr-3 text-lg'>{category.icon}</span>
+                  <span className='font-medium'>{category.name}</span>
+                </div>
+                <svg
+                  className={`w-4 h-4 transition-transform duration-200 ${
+                    openCategories.includes(category.name) ? 'rotate-90' : ''
+                  }`}
+                  fill='none'
+                  stroke='currentColor'
+                  viewBox='0 0 24 24'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M9 5l7 7-7 7'
+                  />
+                </svg>
+              </button>
+
+              {openCategories.includes(category.name) && (
+                <div className='ml-8 mt-1 space-y-1'>
+                  {category.items.map(item => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className='block px-3 py-2 text-sm text-gray-600 hover:text-gray-900 hover:bg-gray-50 rounded-md transition-colors'
+                    >
+                      {item.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #7 

## 📋 작업 내용
/docs 페이지 Ui 구현

## ✅ 변경 사항
- [x] Docs 메인 페이지 레이아웃 구현 (src/app/docs/page.tsx)
- [x] 사이드바 네비게이션 구현 (src/components/docs/Sidebar.tsx)
- [x] 실시간 검색 기능 구현 (src/components/docs/SearchBar.tsx)
- [x] Docs 전용 레이아웃 설정 (src/app/docs/layout.tsx)


## 📷 스크린샷
<img width="1268" height="1013" alt="image" src="https://github.com/user-attachments/assets/1590773b-f8da-4e9f-b2a4-28fba5e43e0f" />