### PR TITLE
feat: 커뮤니티 기본 페이지ui 구현 (#9)

### DIFF
--- a/src/app/community/layout.tsx
+++ b/src/app/community/layout.tsx
@@ -1,0 +1,18 @@
+// src/app/community/layout.tsx
+import React from 'react';
+
+export default function CommunityLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className='min-h-screen'>
+      {/* 현재 커뮤니티 페이지는 특별한 레이아웃이 없으므로,
+        children을 그대로 렌더링합니다.
+        나중에 사이드바나 다른 공통 UI가 필요하면 여기에 추가하면 됩니다.
+      */}
+      {children}
+    </div>
+  );
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -1,0 +1,62 @@
+// src/app/community/page.tsx
+import React from 'react';
+import CommunityHeader from '@/components/community/CommunityHeader';
+import CommunityTabs from '@/components/community/CommunityTabs';
+import PostList from '@/components/community/PostList';
+import Pagination from '@/components/community/Pagination';
+import { Post } from '@/components/community/PostItem'; // Post 타입을 가져와서 사용
+
+// 데이터 타입을 명시적으로 지정하여 오류를 방지합니다.
+const posts: Post[] = [
+  {
+    isNotice: true,
+    id: 'notice',
+    title: '사이트 이용 규칙 및 안내사항',
+    author: '관리자',
+    date: '08.18',
+    views: 1234,
+    likes: 45,
+  },
+  {
+    isNotice: false,
+    id: 2658,
+    title: 'React Hooks 사용법에 대해 질문이 있어요',
+    author: '김개발',
+    date: '08.14',
+    views: 94,
+    likes: 0,
+    comments: 3,
+  },
+  {
+    isNotice: false,
+    id: 2647,
+    title: 'Next.js 배포할 때 계속 에러가 나요 ㅠㅠ',
+    author: '박코딩',
+    date: '08.09',
+    views: 62,
+    likes: 2,
+    comments: 5,
+  },
+  {
+    isNotice: false,
+    id: 2646,
+    title: '자바스크립트 배열 메소드 정리해봤어요',
+    author: '이개발',
+    date: '08.04',
+    views: 51,
+    likes: 8,
+  },
+];
+
+export default function CommunityPage() {
+  return (
+    <div className='bg-white min-h-screen'>
+      <div className='max-w-6xl mx-auto px-4 py-8'>
+        <CommunityHeader />
+        <CommunityTabs />
+        <PostList posts={posts} />
+        <Pagination />
+      </div>
+    </div>
+  );
+}

--- a/src/components/community/CommunityHeader.tsx
+++ b/src/components/community/CommunityHeader.tsx
@@ -1,0 +1,16 @@
+// src/components/community/CommunityHeader.tsx
+import React from 'react';
+
+export default function CommunityHeader() {
+  return (
+    <div className='flex justify-between items-center mb-12'>
+      <div className='flex items-center'>
+        <h1 className='text-3xl font-bold text-gray-900 mr-4'>커뮤니티</h1>
+        <p className='text-gray-600'>일상부터 정보까지 나눠보세요</p>
+      </div>
+      <button className='bg-white text-gray-900 border border-gray-300 px-4 py-2 rounded-lg hover:border-black transition-colors'>
+        글쓰기
+      </button>
+    </div>
+  );
+}

--- a/src/components/community/CommunityTabs.tsx
+++ b/src/components/community/CommunityTabs.tsx
@@ -1,0 +1,19 @@
+// src/components/community/CommunityTabs.tsx
+import React from 'react';
+
+export default function CommunityTabs() {
+  return (
+    <div className='mb-6'>
+      <div className='border-b border-gray-200'>
+        <nav className='flex space-x-8'>
+          <button className='py-2 px-1 border-b-2 border-blue-500 text-blue-600 font-medium'>
+            전체글
+          </button>
+          <button className='py-2 px-1 border-b-2 border-transparent text-gray-500 hover:text-gray-700'>
+            공지
+          </button>
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/src/components/community/Pagination.tsx
+++ b/src/components/community/Pagination.tsx
@@ -1,0 +1,24 @@
+// src/components/community/Pagination.tsx
+import React from 'react';
+
+export default function Pagination() {
+  return (
+    <div className='flex justify-center mt-6'>
+      <div className='flex space-x-2'>
+        <button className='px-3 py-1 border border-gray-300 rounded hover:bg-gray-50'>
+          이전
+        </button>
+        <button className='px-3 py-1 bg-blue-600 text-white rounded'>1</button>
+        <button className='px-3 py-1 border border-gray-300 rounded hover:bg-gray-50'>
+          2
+        </button>
+        <button className='px-3 py-1 border border-gray-300 rounded hover:bg-gray-50'>
+          3
+        </button>
+        <button className='px-3 py-1 border border-gray-300 rounded hover:bg-gray-50'>
+          다음
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/community/PostItem.tsx
+++ b/src/components/community/PostItem.tsx
@@ -1,0 +1,75 @@
+// src/components/community/PostItem.tsx
+
+// 공지 게시글 타입
+interface NoticePost {
+  isNotice: true;
+  id: 'notice'; // 공지사항은 id가 'notice'로 고정
+  title: string;
+  author: string;
+  date: string;
+  views: number;
+  likes: number;
+}
+
+// 일반 게시글 타입
+interface RegularPost {
+  isNotice: false;
+  id: number; // 일반 게시글은 id가 숫자
+  title: string;
+  author: string;
+  date: string;
+  views: number;
+  likes: number;
+  comments?: number;
+}
+
+// 두 타입을 합쳐서 유니온 타입으로 만듭니다.
+export type Post = NoticePost | RegularPost;
+
+interface PostItemProps {
+  post: Post;
+}
+
+export default function PostItem({ post }: PostItemProps) {
+  return (
+    <tr
+      className={
+        post.isNotice
+          ? 'border-b border-gray-100'
+          : 'border-b border-gray-100 hover:bg-gray-50'
+      }
+    >
+      <td className='py-3 px-4 text-center'>
+        {/* 'isNotice' prop을 기준으로 렌더링을 분기합니다. */}
+        {post.isNotice ? (
+          <span className='text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded'>
+            공지
+          </span>
+        ) : (
+          <span className='text-gray-600'>{post.id}</span>
+        )}
+      </td>
+      <td className='py-3 px-4'>
+        <a href='#' className='text-gray-900 hover:text-blue-600 font-medium'>
+          {post.title}
+          {/* 'isNotice'가 false일 때만 comments를 렌더링 */}
+          {!post.isNotice && post.comments && (
+            <span className='text-gray-400'> [{post.comments}]</span>
+          )}
+        </a>
+      </td>
+      <td className='py-3 px-4 text-gray-600 hidden md:table-cell'>
+        {post.author}
+      </td>
+      <td className='py-3 px-4 text-gray-600 hidden md:table-cell'>
+        {post.date}
+      </td>
+      <td className='py-3 px-4 text-gray-600 hidden sm:table-cell text-center'>
+        {post.views.toLocaleString()}
+      </td>
+      <td className='py-3 px-4 text-gray-600 hidden sm:table-cell text-center'>
+        {post.likes.toLocaleString()}
+      </td>
+    </tr>
+  );
+}

--- a/src/components/community/PostList.tsx
+++ b/src/components/community/PostList.tsx
@@ -1,0 +1,45 @@
+// src/components/community/PostList.tsx
+import React from 'react';
+import PostItem from './PostItem';
+import { Post } from './PostItem'; // Post 타입을 가져옵니다.
+
+interface PostListProps {
+  posts: Post[];
+}
+
+export default function PostList({ posts }: PostListProps) {
+  return (
+    <div className='border border-gray-200 overflow-hidden'>
+      <table className='w-full'>
+        <thead className='border-b border-gray-200'>
+          <tr>
+            <th className='text-left py-3 px-4 font-medium text-gray-700 w-16'>
+              번호
+            </th>
+            <th className='text-left py-3 px-4 font-medium text-gray-700'>
+              제목
+            </th>
+            <th className='text-left py-3 px-4 font-medium text-gray-700 hidden md:table-cell w-24'>
+              글쓴이
+            </th>
+            <th className='text-left py-3 px-4 font-medium text-gray-700 hidden md:table-cell w-20'>
+              작성일
+            </th>
+            <th className='text-left py-3 px-4 font-medium text-gray-700 hidden sm:table-cell w-16'>
+              조회
+            </th>
+            <th className='text-left py-3 px-4 font-medium text-gray-700 hidden sm:table-cell w-16'>
+              추천
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {posts.map(post => (
+            // 유니온 타입의 'isNotice'를 기준으로 key를 다르게 설정
+            <PostItem key={post.isNotice ? 'notice' : post.id} post={post} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #9 

## 📋 작업 내용

Community 페이지 기본 ui 구현

## ✅ 변경 사항

- [ ] src/app/community/layout.tsx
- [ ] src/app/community/page.tsx
- [ ] src/components/community/CommunityHeader.tsx
- [ ] src/components/community/CommunityTabs.tsx
- [ ] src/components/community/Pagination.tsx
- [ ] src/components/community/PostList.tsx

제 1순위로 깔끔한 코드, 빠른 수정가능할 수 있게 컴포넌트 분리 

## 📷 스크린샷

<img width="1266" height="871" alt="image" src="https://github.com/user-attachments/assets/bad1278f-067d-441c-9d3a-3437db834e96" />
