### PR TITLE
feat: 메인페이지 Ui 구현 (#15)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  images: {
+    domains: ['avatars.githubusercontent.com'],
+  },
 };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,13 @@
-import Image from "next/image";
+// src/app/page.tsx
+import React from 'react';
+import DynamicContent from '@/components/main/DynamicContent';
+import Contributors from '@/components/main/Contributors';
 
-export default function Home() {
+export default function MainPage() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+    <div className='min-h-screen bg-white'>
+      <Contributors />
+      <DynamicContent />
     </div>
   );
 }

--- a/src/components/main/Contributors.tsx
+++ b/src/components/main/Contributors.tsx
@@ -1,0 +1,59 @@
+// src/components/main/Contributors.tsx
+import React from 'react';
+import MarqueeRow from './MarqueeRow';
+import { fetchContributors, repeatData } from '@/lib/data/contributors';
+
+// CSS Keyframe 애니메이션 정의
+const marqueeAnimation = `
+  @keyframes scrollLeft {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+  }
+  @keyframes scrollRight {
+    0% { transform: translateX(-50%); }
+    100% { transform: translateX(0); }
+  }
+`;
+
+// 메인 컴포넌트 (서버 컴포넌트)
+export default async function Contributors() {
+  const contributors = await fetchContributors();
+  const repeatedContributors = repeatData(contributors, 2);
+
+  return (
+    <div className='bg-white py-16 px-4 text-center overflow-hidden'>
+      <style>{marqueeAnimation}</style>
+
+      <h2 className='text-3xl font-bold mb-3 text-gray-900'>
+        당신의 지식을 공유해주세요
+      </h2>
+      <p className='text-lg text-gray-600 mb-12'>우리는 같이 성장해나갑니다</p>
+
+      <div className='flex flex-col space-y-8'>
+        <div className='flex justify-center w-full'>
+          <MarqueeRow
+            contributors={repeatedContributors}
+            duration={60}
+            direction='left'
+          />
+        </div>
+
+        <div className='flex justify-center w-full'>
+          <MarqueeRow
+            contributors={repeatedContributors}
+            duration={70}
+            direction='right'
+          />
+        </div>
+
+        <div className='flex justify-center w-full'>
+          <MarqueeRow
+            contributors={repeatedContributors}
+            duration={80}
+            direction='left'
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main/DynamicContent.tsx
+++ b/src/components/main/DynamicContent.tsx
@@ -1,0 +1,120 @@
+// src/components/main/DynamicContent.tsx
+import React from 'react';
+import Link from 'next/link';
+
+// Docs API에서 가져오는 파일의 타입 정의
+interface DocsFile {
+  name: string;
+  path: string;
+  type: 'file' | 'dir';
+  download_url?: string;
+  content?: string;
+}
+
+// 이전에 작성했던 GitHub API 함수를 가져옵니다.
+// 경로는 실제 프로젝트 구조에 맞게 수정해주세요.
+import { getDocsFiles } from '@/lib/github';
+
+// 커뮤니티 더미 데이터 (아직 API가 없으므로 그대로 사용)
+const latestCommunity = [
+  {
+    title: 'Next.js 배포할 때 계속 에러가 나요 ㅠㅠ',
+    link: '#',
+    date: '08.24',
+    likes: 2,
+    comments: 5,
+  },
+  {
+    title: '신입 개발자 자기계발 스터디',
+    link: '#',
+    date: '08.24',
+    likes: 3,
+    comments: 1,
+  },
+  {
+    title: '4개월차 자괴감이 너무 듭니다',
+    link: '#',
+    date: '08.23',
+    likes: 10,
+    comments: 2,
+  },
+  {
+    title: '백엔드 언어 선택 고민',
+    link: '#',
+    date: '08.22',
+    likes: 5,
+    comments: 0,
+  },
+  {
+    title: '자사 서비스 개발 회사에 입사하는게 목표인데...',
+    link: '#',
+    date: '08.21',
+    likes: 8,
+    comments: 6,
+  },
+];
+
+// 컴포넌트를 비동기 함수로 만들어 서버 컴포넌트로 작동하게 합니다.
+export default async function DynamicContent() {
+  // Docs API를 호출하여 실제 파일 목록을 가져옵니다.
+  const docsFiles: DocsFile[] = await getDocsFiles();
+
+  // 최신 Docs 파일 5개만 필터링하고 UI에 맞게 데이터를 변환합니다.
+  const latestDocs = docsFiles
+    .filter(file => file.type === 'file') // 파일만 남기고
+    .slice(0, 5) // 최신 5개만 선택
+    .map(file => ({
+      // API 응답 데이터를 UI 데이터 형식에 맞게 변환합니다.
+      title: file.name.replace(/\.md$/, ''), // 파일명에서 확장자 제거
+      link: `/docs/${file.path}`, // Docs 페이지 링크
+      date: 'N/A', // GitHub API 응답에 직접적인 날짜/조회수 데이터가 없어 더미값 사용
+      views: 0,
+      likes: 0,
+    }));
+
+  return (
+    <div className='max-w-6xl mx-auto grid grid-cols-1 md:grid-cols-2 gap-8'>
+      {/* Docs 섹션 */}
+      <div className='bg-white p-6 rounded-xl shadow-md'>
+        <h2 className='text-2xl font-bold mb-4 border-b border-gray-200 pb-2'>
+          Docs
+        </h2>
+        <ul className='space-y-4'>
+          {latestDocs.map((doc, index) => (
+            <li key={index} className='flex justify-between items-center'>
+              <Link href={doc.link} className='flex-1 hover:underline'>
+                <span className='font-medium text-gray-800'>{doc.title}</span>
+              </Link>
+              <div className='flex items-center text-sm text-gray-500 space-x-2'>
+                <span>{doc.date}</span>
+                <span>조회 {doc.views}</span>
+                <span>추천 {doc.likes}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Community 섹션 */}
+      <div className='bg-white p-6 rounded-xl shadow-md'>
+        <h2 className='text-2xl font-bold mb-4 border-b border-gray-200 pb-2'>
+          커뮤니티
+        </h2>
+        <ul className='space-y-4'>
+          {latestCommunity.map((post, index) => (
+            <li key={index} className='flex justify-between items-center'>
+              <Link href={post.link} className='flex-1 hover:underline'>
+                <span className='font-medium text-gray-800'>{post.title}</span>
+              </Link>
+              <div className='flex items-center text-sm text-gray-500 space-x-2'>
+                <span>{post.date}</span>
+                <span>추천 {post.likes}</span>
+                <span>댓글 {post.comments}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/components/main/MarqueeRow.tsx
+++ b/src/components/main/MarqueeRow.tsx
@@ -1,0 +1,51 @@
+// src/components/main/MarqueeRow.tsx
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { Contributor } from '@/types/contributors';
+
+// Contributor 인터페이스 확장 (uniqueKey 포함)
+interface MarqueeContributor extends Contributor {
+  uniqueKey: string;
+}
+
+interface MarqueeRowProps {
+  contributors: MarqueeContributor[];
+  duration: number;
+  direction: 'left' | 'right';
+}
+
+const MarqueeRow: React.FC<MarqueeRowProps> = ({
+  contributors,
+  duration,
+  direction,
+}) => {
+  return (
+    <div
+      className='flex-shrink-0 flex items-center justify-around'
+      style={{
+        animation: `${direction === 'right' ? 'scrollRight' : 'scrollLeft'} ${duration}s linear infinite`,
+      }}
+    >
+      {contributors.map(contributor => (
+        <Link
+          key={contributor.uniqueKey}
+          href={contributor.githubUrl}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='flex-shrink-0 w-20 h-20 mx-4 transition-transform duration-300 hover:scale-110'
+        >
+          <Image
+            src={contributor.imageUrl}
+            alt='Contributor'
+            width={80}
+            height={80}
+            className='rounded-full'
+          />
+        </Link>
+      ))}
+    </div>
+  );
+};
+
+export default MarqueeRow;

--- a/src/lib/data/contributors.ts
+++ b/src/lib/data/contributors.ts
@@ -1,0 +1,62 @@
+import { Contributor } from '@/types/contributors';
+
+export const githubUsernames: string[] = [
+  'Jay-klmnop',
+  'jngmnj',
+  'devsplatform',
+  'idubusomuch',
+  'yeontae519',
+  'kyukyu300',
+  'HyeonchanLim',
+  'han-nun0107',
+  'quartzs2',
+  'L1m3Kun',
+  'yongarframe',
+  'soyeon1351',
+  'devjaesung',
+  'ella6010',
+];
+
+export const fetchContributors = async (): Promise<Contributor[]> => {
+  const uniqueUsers = Array.from(new Set(githubUsernames));
+
+  const contributorsData = await Promise.all(
+    uniqueUsers.map(async username => {
+      const res = await fetch(`https://api.github.com/users/${username}`, {
+        next: { revalidate: 3600 },
+      });
+      if (!res.ok) {
+        console.error(`Failed to fetch GitHub user: ${username}`);
+        return {
+          githubUrl: '#',
+          imageUrl: 'https://via.placeholder.com/80?text=?',
+          username,
+        };
+      }
+      const user = await res.json();
+      return {
+        githubUrl: user.html_url,
+        imageUrl: user.avatar_url,
+        username: user.login,
+      };
+    })
+  );
+
+  return contributorsData;
+};
+
+// 무한 스크롤을 위해 데이터를 여러 번 복제하는 함수
+export const repeatData = (
+  data: Contributor[],
+  count: number
+): (Contributor & { uniqueKey: string })[] => {
+  let repeated: (Contributor & { uniqueKey: string })[] = [];
+  for (let i = 0; i < count; i++) {
+    const keyedData = data.map(item => ({
+      ...item,
+      uniqueKey: `${item.username}-${i}`,
+    }));
+    repeated = [...repeated, ...keyedData];
+  }
+  return repeated;
+};

--- a/src/types/contributors.ts
+++ b/src/types/contributors.ts
@@ -1,0 +1,5 @@
+export interface Contributor {
+  githubUrl: string;
+  imageUrl: string;
+  username: string;
+}


### PR DESCRIPTION
### 🔗 관련 이슈

Closes #15

### 📋 작업 내용

이 Pull Request는 메인 페이지를 구현하고, 관련 컴포넌트를 개선하여 포트폴리오의 완성도를 높이는 것을 목표로 합니다.

### ✅ 변경 사항

- 메인 페이지(`src/app/page.tsx`)를 포트폴리오 컨셉에 맞춰 간결하게 재구성했습니다.
- `DynamicContent` 컴포넌트가 더미 데이터 대신 GitHub API를 통해 동적으로 문서를 표시하도록 연동했습니다.
- `Contributors` 컴포넌트를 GitHub API를 통해 프로필 이미지를 자동으로 가져오는 무한 스크롤 애니메이션으로 개선했습니다.
- API 호출 및 데이터 로직(`fetchContributors`, `repeatData`)을 `src/lib/data/contributors.ts` 파일로 분리하여 코드 가독성과 유지보수성을 높였습니다.
- `next/image` 설정 오류, React `key` 중복 오류, 그리고 애니메이션의 빈 공간 문제를 모두 해결했습니다.

### 📷 스크린샷

<img width="1253" height="940" alt="image" src="https://github.com/user-attachments/assets/871f8fde-f387-40bc-a1bf-a97bdf5fc0e4" />

