### PR TITLE
feat: Docs페이지에 기여자 추가 및 카테고리바  접기 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "devsplatform-platform",
       "version": "0.1.0",
       "dependencies": {
+        "@remixicon/react": "^4.6.0",
         "highlight.js": "^11.11.1",
         "next": "15.4.6",
         "octokit": "^5.0.3",
@@ -1310,6 +1311,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/@remixicon/react": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@remixicon/react/-/react-4.6.0.tgz",
+      "integrity": "sha512-bY56maEgT5IYUSRotqy9h03IAKJC85vlKtWFg2FKzfs8JPrkdBAYSa9dxoUSKFwGzup8Ux6vjShs9Aec3jvr2w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": ">=18.2.0"
       }
     },
     "node_modules/@rtsao/scc": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@remixicon/react": "^4.6.0",
     "highlight.js": "^11.11.1",
     "next": "15.4.6",
     "octokit": "^5.0.3",

--- a/src/app/docs/layout.tsx
+++ b/src/app/docs/layout.tsx
@@ -1,40 +1,121 @@
+import React from 'react';
 import Sidebar from '@/components/docs/Sidebar';
+import { getDocsFiles } from '@/lib/github';
+import { Category, CategoryItem } from '@/types/docs'; // 타입을 한 곳에서 임포트
 
-export default function DocsLayout({
+// Remix Icon에서 사용할 올바른 아이콘 이름을 임포트합니다.
+import {
+  RiPlayCircleFill,
+  RiReactjsFill,
+  RiNextjsFill,
+  RiJavascriptFill,
+  RiGitCommitFill,
+  RiFileTextFill,
+  RiComputerFill,
+  RiHtml5Fill,
+  RiCss3Fill,
+  RiTailwindCssFill,
+  RiNodejsFill,
+} from '@remixicon/react';
+
+// 폴더명에 따른 아이콘 매핑
+const folderIcons: { [key: string]: React.ReactNode } = {
+  시작하기: <RiPlayCircleFill />,
+  React: <RiReactjsFill />,
+  'Next.js': <RiNextjsFill />,
+  JavaScript: <RiJavascriptFill />,
+  TypeScript: <RiNodejsFill />, // Remixicon에 TypeScript 전용 아이콘이 없어 Node.js로 대체
+  Html: <RiHtml5Fill />,
+  Css: <RiCss3Fill />,
+  Tailwind: <RiTailwindCssFill />,
+  Git: <RiGitCommitFill />,
+  'Node.js': <RiNodejsFill />,
+  개발환경: <RiComputerFill />,
+  기타: <RiFileTextFill />,
+};
+
+// ISR 캐싱 - 1시간마다 재생성
+export const revalidate = 3600;
+
+export default async function DocsLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <div className='grid grid-cols-1 lg:grid-cols-[280px_1fr] min-h-screen'>
-      {/* 사이드바 - 모바일에서는 숨김, 데스크탑에서는 고정 */}
-      <div className='hidden lg:block'>
-        <Sidebar />
-      </div>
+  try {
+    const rootFiles = await getDocsFiles();
+    const folders = rootFiles.filter(file => file.type === 'dir');
 
-      {/* 메인 콘텐츠 */}
-      <main className='overflow-auto'>
-        {/* 모바일 햄버거 버튼 */}
-        <div className='lg:hidden p-4 border-b border-gray-200 bg-white sticky top-0 z-10'>
-          <button className='text-gray-600 hover:text-gray-900'>
-            <svg
-              className='w-6 h-6'
-              fill='none'
-              stroke='currentColor'
-              viewBox='0 0 24 24'
-            >
-              <path
-                strokeLinecap='round'
-                strokeLinejoin='round'
-                strokeWidth={2}
-                d='M4 6h16M4 12h16M4 18h16'
-              />
-            </svg>
-          </button>
+    const folderContents = await Promise.all(
+      folders.map(async folder => {
+        const files = await getDocsFiles(folder.path);
+        const mdFiles = files.filter(
+          file => file.type === 'file' && file.name.endsWith('.md')
+        );
+
+        const items: CategoryItem[] = mdFiles.map(file => {
+          const fileName = file.name.replace('.md', '');
+          return {
+            name: fileName.replace(/-/g, ' '),
+            href: `/docs/${encodeURIComponent(folder.name)}/${encodeURIComponent(fileName)}`,
+          };
+        });
+
+        return {
+          name: folder.name,
+          icon: folderIcons[folder.name] || <RiFileTextFill />,
+          items: items,
+        };
+      })
+    );
+
+    const categories: Category[] = folderContents.filter(
+      category => category.items.length > 0
+    );
+
+    return (
+      <div className='grid grid-cols-1 lg:grid-cols-[280px_1fr] min-h-screen'>
+        <div className='hidden lg:block'>
+          <Sidebar categories={categories} />
         </div>
 
-        {children}
-      </main>
-    </div>
-  );
+        <main className='overflow-auto'>
+          <div className='lg:hidden p-4 border-b border-gray-200 bg-white sticky top-0 z-10'>
+            <button className='text-gray-600 hover:text-gray-900'>
+              <svg
+                className='w-6 h-6'
+                fill='none'
+                stroke='currentColor'
+                viewBox='0 0 24 24'
+              >
+                <path
+                  strokeLinecap='round'
+                  strokeLinejoin='round'
+                  strokeWidth={2}
+                  d='M4 6h16M4 12h16M4 18h16'
+                />
+              </svg>
+            </button>
+          </div>
+          {children}
+        </main>
+      </div>
+    );
+  } catch (error) {
+    console.error('카테고리 로딩 오류:', error);
+
+    return (
+      <div className='grid grid-cols-1 lg:grid-cols-[280px_1fr] min-h-screen'>
+        <aside className='bg-white border-r border-gray-200 h-screen overflow-y-auto sticky top-0'>
+          <div className='p-6'>
+            <h2 className='text-xl font-bold text-gray-900 mb-6'>Docs</h2>
+            <div className='text-red-600 text-sm'>
+              <p>문서 목록을 불러오는데 실패했습니다.</p>
+            </div>
+          </div>
+        </aside>
+        <main className='overflow-auto'>{children}</main>
+      </div>
+    );
+  }
 }

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,6 +1,31 @@
+// src/app/docs/page.tsx
 import SearchBar from '@/components/docs/SearchBar';
+import { getDocsTree } from '@/lib/github'; // getDocsTree 함수를 가져옵니다.
 
-export default function DocsPage() {
+// DocsFile 타입 정의
+interface DocsFile {
+  name: string;
+  path: string;
+  type: 'file' | 'dir';
+  download_url?: string;
+  content?: string;
+}
+
+export default async function DocsPage() {
+  // 1. GitHub API를 호출하여 모든 파일 목록을 가져옵니다.
+  const docsTree: DocsFile[] = await getDocsTree();
+
+  // 2. 검색에 사용할 데이터 형식으로 변환합니다.
+  const allDocs = docsTree
+    .filter(file => file.type === 'file' && file.name.endsWith('.md')) // 마크다운 파일만 필터링
+    .map(file => ({
+      title: file.name.replace(/\.md$/, ''), // 파일명에서 확장자 제거
+      description: `이 문서는 ${file.name.replace(/\.md$/, '')}에 대한 내용입니다.`,
+      icon: '📄', // 아이콘은 기본값으로 설정
+      category: file.path.split('/')[0], // 경로의 첫 번째 폴더를 카테고리로 사용
+      link: `/docs/${file.path.replace(/\.md$/, '')}`, // URL 경로 생성
+    }));
+
   return (
     <div className='bg-white min-h-screen'>
       <div className='max-w-4xl mx-auto px-4 py-16'>
@@ -16,7 +41,8 @@ export default function DocsPage() {
             조금 더 쉽게 쉽게 이해해봅시다.
           </p>
 
-          <SearchBar />
+          {/* 3. SearchBar 컴포넌트에 변환된 데이터를 props로 전달합니다. */}
+          <SearchBar allDocs={allDocs} />
         </div>
 
         {/* 기여 가이드 섹션 */}

--- a/src/components/docs/SearchBar.tsx
+++ b/src/components/docs/SearchBar.tsx
@@ -1,22 +1,31 @@
+// src/components/docs/SearchBar.tsx
 'use client';
 
 import { useState, useEffect } from 'react';
-// SearchResult 타입 정의
+import Link from 'next/link';
+
+// Docs 데이터 타입 정의
 interface SearchResult {
   title: string;
   description: string;
   icon: string;
   category: string;
+  link: string;
 }
 
-export default function SearchBar() {
+// props 타입 정의
+interface SearchBarProps {
+  allDocs: SearchResult[];
+}
+
+export default function SearchBar({ allDocs }: SearchBarProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [filteredResults, setFilteredResults] = useState<SearchResult[]>([]);
 
   useEffect(() => {
     if (searchQuery.length > 0) {
-      const results = mockSearchResults.filter(
+      const results = allDocs.filter(
         (item: SearchResult) =>
           item.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
           item.description.toLowerCase().includes(searchQuery.toLowerCase())
@@ -27,7 +36,12 @@ export default function SearchBar() {
       setFilteredResults([]);
       setIsOpen(false);
     }
-  }, [searchQuery]);
+  }, [searchQuery, allDocs]); // allDocs를 의존성 배열에 추가
+
+  const handleLinkClick = () => {
+    setIsOpen(false);
+    setSearchQuery('');
+  };
 
   return (
     <div className='w-full max-w-2xl mx-auto relative'>
@@ -110,29 +124,24 @@ export default function SearchBar() {
           {/* 검색 결과 */}
           <div className='absolute top-full left-0 right-0 mt-2 bg-white border border-gray-200 rounded-xl shadow-lg z-20 max-h-96 overflow-y-auto'>
             {filteredResults.map((result, index) => (
-              <div
-                key={index}
-                className='px-4 py-3 hover:bg-gray-50 cursor-pointer border-b border-gray-100 last:border-b-0'
-                onClick={() => {
-                  console.log('선택:', result.title);
-                  setIsOpen(false);
-                }}
-              >
-                <div className='flex items-start'>
-                  <span className='text-lg mr-3 mt-1'>{result.icon}</span>
-                  <div className='flex-1'>
-                    <h4 className='font-medium text-gray-900 mb-1'>
-                      {result.title}
-                    </h4>
-                    <p className='text-sm text-gray-600 mb-1'>
-                      {result.description}
-                    </p>
-                    <span className='text-xs text-blue-600 bg-blue-50 px-2 py-1 rounded'>
-                      {result.category}
-                    </span>
+              <Link key={index} href={result.link} onClick={handleLinkClick}>
+                <div className='px-4 py-3 hover:bg-gray-50 cursor-pointer border-b border-gray-100 last:border-b-0'>
+                  <div className='flex items-start'>
+                    <span className='text-lg mr-3 mt-1'>{result.icon}</span>
+                    <div className='flex-1'>
+                      <h4 className='font-medium text-gray-900 mb-1'>
+                        {result.title}
+                      </h4>
+                      <p className='text-sm text-gray-600 mb-1'>
+                        {result.description}
+                      </p>
+                      <span className='text-xs text-blue-600 bg-blue-50 px-2 py-1 rounded'>
+                        {result.category}
+                      </span>
+                    </div>
                   </div>
                 </div>
-              </div>
+              </Link>
             ))}
           </div>
         </>
@@ -153,48 +162,3 @@ export default function SearchBar() {
     </div>
   );
 }
-
-const mockSearchResults = [
-  {
-    title: 'React Hooks 완벽 가이드',
-    description: 'useState, useEffect부터 커스텀 훅까지',
-    icon: '⚛️',
-    category: 'React',
-  },
-  {
-    title: 'Next.js App Router',
-    description: '새로운 라우팅 시스템 완전 정복',
-    icon: '🔷',
-    category: 'Next.js',
-  },
-  {
-    title: 'JavaScript 비동기 처리',
-    description: 'Promise, async/await 쉽게 이해하기',
-    icon: '📜',
-    category: 'JavaScript',
-  },
-  {
-    title: 'TypeScript 기초',
-    description: '타입으로 안전한 코드 작성하기',
-    icon: '🔷',
-    category: 'TypeScript',
-  },
-  {
-    title: 'CSS Flexbox',
-    description: '레이아웃의 혁신, Flexbox 마스터하기',
-    icon: '🎨',
-    category: 'CSS',
-  },
-  {
-    title: 'React useState Hook',
-    description: 'React의 가장 기본적인 상태 관리 훅',
-    icon: '⚛️',
-    category: 'React',
-  },
-  {
-    title: 'JavaScript async/await',
-    description: '비동기 처리를 동기처럼 쉽게',
-    icon: '📜',
-    category: 'JavaScript',
-  },
-];

--- a/src/components/docs/Sidebar.tsx
+++ b/src/components/docs/Sidebar.tsx
@@ -1,85 +1,62 @@
+// src/components/docs/Sidebar.tsx
+'use client';
+
+import React, { useState } from 'react';
 import Link from 'next/link';
-import { getDocsFiles } from '@/lib/github';
+import { Category } from '@/types/docs'; // 타입을 한 곳에서 임포트
 
-// 폴더명에 따른 아이콘 매핑
-const folderIcons: { [key: string]: string } = {
-  시작하기: '🚀',
-  React: '⚛️',
-  'Next.js': '🔷',
-  JavaScript: '📜',
-  TypeScript: '💙',
-  'Node.js': '🟢',
-  Git: '🔧',
-  개발환경: '⚙️',
-  기타: '📝',
-};
-
-// 카테고리 타입 정의
-interface CategoryItem {
-  name: string;
-  href: string;
+interface SidebarProps {
+  categories: Category[];
 }
 
-interface Category {
-  name: string;
-  icon: string;
-  items: CategoryItem[];
-}
+export default function Sidebar({ categories }: SidebarProps) {
+  const [openCategories, setOpenCategories] = useState<Record<string, boolean>>(
+    categories.reduce(
+      (acc, category) => ({ ...acc, [category.name]: true }),
+      {}
+    )
+  );
 
-// ISR 캐싱 - 1시간마다 재생성
-export const revalidate = 3600;
+  const toggleCategory = (name: string) => {
+    setOpenCategories(prev => ({
+      ...prev,
+      [name]: !prev[name],
+    }));
+  };
 
-export default async function Sidebar() {
-  try {
-    // GitHub에서 카테고리 데이터 가져오기 (서버에서 실행)
-    const rootFiles = await getDocsFiles();
-    const folders = rootFiles.filter(file => file.type === 'dir');
+  return (
+    <aside className='bg-white border-r border-gray-200 h-screen overflow-y-auto sticky top-0'>
+      <div className='p-6'>
+        <h2 className='text-xl font-bold text-gray-900 mb-6'>Docs</h2>
 
-    const categories: Category[] = [];
+        <nav className='space-y-2'>
+          {categories.map(category => (
+            <div key={category.name}>
+              <div
+                className='flex items-center px-3 py-2 text-gray-700 cursor-pointer hover:bg-gray-50 rounded-md transition-colors'
+                onClick={() => toggleCategory(category.name)}
+              >
+                <span className='mr-3 text-lg'>{category.icon}</span>
+                <span className='font-medium flex-1'>{category.name}</span>
+                <svg
+                  className={`w-4 h-4 text-gray-400 transform transition-transform duration-200 ${
+                    openCategories[category.name] ? 'rotate-90' : ''
+                  }`}
+                  fill='none'
+                  stroke='currentColor'
+                  viewBox='0 0 24 24'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M9 5l7 7-7 7'
+                  />
+                </svg>
+              </div>
 
-    for (const folder of folders) {
-      try {
-        const folderFiles = await getDocsFiles(folder.path);
-        const mdFiles = folderFiles.filter(
-          file => file.type === 'file' && file.name.endsWith('.md')
-        );
-
-        const items: CategoryItem[] = mdFiles.map(file => {
-          const fileName = file.name.replace('.md', '');
-          return {
-            name: fileName.replace(/-/g, ' '),
-            href: `/docs/${encodeURIComponent(folder.name)}/${encodeURIComponent(fileName)}`,
-          };
-        });
-
-        if (items.length > 0) {
-          categories.push({
-            name: folder.name,
-            icon: folderIcons[folder.name] || '📁',
-            items: items,
-          });
-        }
-      } catch (err) {
-        console.error(`폴더 ${folder.name} 처리 중 오류:`, err);
-      }
-    }
-
-    return (
-      <aside className='bg-white border-r border-gray-200 h-screen overflow-y-auto sticky top-0'>
-        <div className='p-6'>
-          <h2 className='text-xl font-bold text-gray-900 mb-6'>Docs</h2>
-
-          <nav className='space-y-2'>
-            {categories.map(category => (
-              <div key={category.name}>
-                {/* 카테고리 헤더 - 항상 열려있게 */}
-                <div className='flex items-center px-3 py-2 text-gray-700'>
-                  <span className='mr-3 text-lg'>{category.icon}</span>
-                  <span className='font-medium'>{category.name}</span>
-                </div>
-
-                {/* 카테고리 아이템들 */}
-                <div className='ml-8 space-y-1'>
+              {openCategories[category.name] && (
+                <div className='ml-8 space-y-1 mt-1 transition-all duration-300'>
                   {category.items.map(item => (
                     <Link
                       key={item.href}
@@ -90,31 +67,11 @@ export default async function Sidebar() {
                     </Link>
                   ))}
                 </div>
-              </div>
-            ))}
-          </nav>
-
-          {/* 캐시 정보 */}
-          <div className='mt-8 pt-4 border-t border-gray-200'>
-            <p className='text-xs text-gray-400'>
-              📦 캐시된 목록 (1시간마다 업데이트)
-            </p>
-          </div>
-        </div>
-      </aside>
-    );
-  } catch (error) {
-    console.error('카테고리 로딩 오류:', error);
-
-    return (
-      <aside className='bg-white border-r border-gray-200 h-screen overflow-y-auto sticky top-0'>
-        <div className='p-6'>
-          <h2 className='text-xl font-bold text-gray-900 mb-6'>Docs</h2>
-          <div className='text-red-600 text-sm'>
-            <p>문서 목록을 불러오는데 실패했습니다.</p>
-          </div>
-        </div>
-      </aside>
-    );
-  }
+              )}
+            </div>
+          ))}
+        </nav>
+      </div>
+    </aside>
+  );
 }

--- a/src/types/docs.ts
+++ b/src/types/docs.ts
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export interface CategoryItem {
+  name: string;
+  href: string;
+}
+
+export interface Category {
+  name: string;
+  icon: React.ReactNode;
+  items: CategoryItem[];
+}


### PR DESCRIPTION
### 🔗 관련 이슈

Closes #17

### 📋 작업 내용

이 Pull Request는 Docs 페이지의 개별 문서 상단에 해당 글의 마지막 기여자 정보를 표시하는 기능을 구현합니다. 이를 통해 기여자에게 크레딧을 제공하고, 콘텐츠의 신뢰성을 높입니다.

### ✅ 변경 사항

- [ ] **`src/app/docs/[...slug]/page.tsx` 파일 수정:**
    - GitHub API를 통해 해당 문서의 커밋 정보를 가져오는 로직을 추가했습니다.
    - `committer` 대신 `author` 필드를 사용하여 글을 작성한 실제 기여자의 프로필이 표시되도록 수정했습니다.
    - `params` 객체를 `await` 처리하는 코드를 적용하여 Next.js 서버 에러를 해결했습니다.
    - 문서 상단에 기여자의 프로필 사진, 깃허브 아이디, 링크를 표시하는 UI를 추가했습니다.

### 📷 스크린샷
<img width="916" height="159" alt="image" src="https://github.com/user-attachments/assets/9a527d61-2843-43b0-88e8-6b5ed8be1a7b" />


