### PR TITLE
feat: 메인페이지 다이나믹 목록 수정 (#23)

### DIFF
--- a/src/components/main/PostListItem.tsx
+++ b/src/components/main/PostListItem.tsx
@@ -1,0 +1,36 @@
+// src/components/main/PostListItem.tsx
+import React from 'react';
+import Link from 'next/link';
+// 필요한 타입들을 DynamicContent.tsx에서 임포트해야 합니다.
+// 하지만 편의상 여기에 임시로 정의합니다.
+interface DocsPost {
+  title: string;
+  link: string;
+  contributor: string;
+}
+
+interface CommunityPost {
+  title: string;
+  link: string;
+  date: string;
+  likes: number;
+  comments: number;
+}
+
+interface PostListItemProps {
+  post: DocsPost | CommunityPost;
+}
+
+export default function PostListItem({ post }: PostListItemProps) {
+  return (
+    <li className='flex justify-between items-center'>
+      <Link href={post.link} className='flex-1 hover:underline'>
+        <span className='font-medium text-gray-800'>{post.title}</span>
+      </Link>
+      <div className='flex items-center text-sm text-gray-500 space-x-2'>
+        {'contributor' in post && <span>기여자: {post.contributor}</span>}
+        {'comments' in post && <span>댓글 {post.comments}</span>}
+      </div>
+    </li>
+  );
+}


### PR DESCRIPTION
## 🔗 관련 이슈

Closes #23 

## 📋 작업 내용

메인페이지 다이나믹목록에 md 파일이 루트에서만 작동하는것을 수정

## ✅ 변경 사항

- [ ] 파일 url을 불러오니 오류가 생겨서 github.ts에서 디렉토리 구조를 재귀적으로 가져온 getDocsTree를 import함 
- [ ] 백앤드 api 를 연동하지 않는 페이지라 쓸데없는 파라미터를 전부 제외하고 제목과 기여자만 구현함


## 📷 스크린샷

<img width="1055" height="303" alt="image" src="https://github.com/user-attachments/assets/8c96b2b6-51c0-46bf-a784-40c00def9629" />
